### PR TITLE
Add tests for initialize arguments

### DIFF
--- a/test/00_setup/test_try_out.rb
+++ b/test/00_setup/test_try_out.rb
@@ -7,7 +7,7 @@ class TestTryOut < MiniTest::Test
     assert_equal "John Wick", target.full_name
   end
 
-  def test_fist_middle_last_name
+  def test_first_middle_last_name
     target = TryOut.new("Keanu", "Charies",  "Reeves")
     assert_equal "Keanu Charies Reeves", target.full_name
   end
@@ -38,6 +38,14 @@ class TestTryOut < MiniTest::Test
     target = TryOut.new("Murphy", "McManus")
     target.upcase_full_name!
     assert_equal "MURPHY MCMANUS", target.full_name
+  end
+
+  def test_too_few_arguments
+    assert_raises (ArgumentError) {TryOut.new("John")}
+  end
+
+  def test_too_many_arguments
+    assert_raises (ArgumentError) {TryOut.new("John", "Milton", "Cage", "Jr")}
   end
 end
 


### PR DESCRIPTION
> コンストラクタは、2つまたは3つの引数を受け付ける。引数はそれぞれ、ファーストネーム、ミドルネーム、ラストネームの順で、ミドルネームは省略が可能。

上記の仕様に従い、 `TryOut.new` の引数が1つまたは4つの場合に例外が発生するテストを追加しました。