### PR TITLE
try_over3_3.rbのQ5. チャレンジ問題！にtaskで定義したClass以外で呼び出すテストを追加

### DIFF
--- a/test/03_method/test_try_over3_3.rb
+++ b/test/03_method/test_try_over3_3.rb
@@ -103,6 +103,10 @@ class TestTryOver03Q1 < Minitest::Test
     assert_match "Warning: TryOver3::A5Task::Foo.run is duplicated", err
   end
 
+  def test_q5_error_when_called_not_defined_task_class
+    assert_raises(NameError) { TryOver3::A5Task::Bar.run }
+  end
+
   private
 
   def alpha_rand(size = 8)


### PR DESCRIPTION
既存testだと下記のような実装(const_missingのsuperを呼び出してない)にした場合に`TryOver3::A5Task::Bar.run`といったtaskで定義していないようなClassを使った呼び出し方でも通ってしまったので、定義したClass以外はNameErrorが発生することを確認するtestを追加しました。

``` ruby
TryOver3 = Module.new
module TryOver3::TaskHelper
  def self.included(klass)
    klass.define_singleton_method :task do |name, &task_block|
      singleton_class.define_method(:run_task) do |const_name: '', deplicated: false|
        warn "Warning: #{self}::#{const_name}.run is duplicated" if deplicated
        puts "start #{Time.now}"
        block_return = task_block.call
        puts "finish #{Time.now}"
        block_return
      end
      private_class_method :run_task

      singleton_class.define_method(name) { run_task }
      singleton_class.define_method(:const_missing) do |const_name|
        new_klass_name = name.to_s.split("_").map{ |w| w[0] = w[0].upcase; w }.join
        # return super(const_name) if new_klass_name.to_sym != const_name # ここが無くても通る
        tap { |obj| obj.class.define_method(:run) { run_task(const_name: const_name, deplicated: true) } }
      end
    end
  end
end

class TryOver3::A5Task
  include TryOver3::TaskHelper

  task :foo do
    "foo"
  end
end

TryOver3::A5Task::Bar.run
Warning: TryOver3::A5Task::Bar.run is duplicated
start 2020-03-04 00:19:21 +0900
finish 2020-03-04 00:19:21 +0900
=> "foo"
```