### PR TITLE
Add multiple accessors test for 05_class_definition/simple_model.rb

### DIFF
--- a/test/05_class_definition/test_simple_record.rb
+++ b/test/05_class_definition/test_simple_record.rb
@@ -68,4 +68,25 @@ class TestSimpleRecord < MiniTest::Test
     assert_equal name, obj.name
     assert_equal desc, obj.description
   end
+
+  class MultipleAccessorsProduct
+    include SimpleModel
+
+    attr_accessor :name
+    attr_accessor :description
+  end
+
+  def test_accessor
+    obj = MultipleAccessorsProduct.new(name: 'SmarterHR', description: 'more smart SmartHR')
+    assert_equal 'SmarterHR', obj.name
+    assert_equal 'more smart SmartHR', obj.description
+  end
+
+  def test_writer
+    obj = MultipleAccessorsProduct.new(name: 'SmarterHR', description: 'more smart SmartHR')
+    obj.name = 'Ultra SmarterHR'
+    obj.description = 'more smart SmarterHR'
+    assert_equal 'Ultra SmarterHR', obj.name
+    assert_equal 'more smart SmarterHR', obj.description
+  end
 end


### PR DESCRIPTION
`05_class_definition/simple_model.rb`

上問題のテストケースにおいて、`attr_accessor` を一度定義するテストケースしかなかったので、複数の 、`attr_accessor` を定義していも同様な挙動になることを保証するようなテストケースを追加しました。

これによって `attr_accessor`  内で毎回 attribute 定義を初期化するようなコードを書いていると落ちるようになります。