### PR TITLE
expectsとwatchを併用したときに、両方に求められている仕様を満たしているかのチェックがなかったので足した

### DIFF
--- a/05_class_definition/simple_mock.rb
+++ b/05_class_definition/simple_mock.rb
@@ -33,7 +33,7 @@
 # obj = SimpleMock.new
 # obj.expects(:imitated_method, true)
 # obj.watch(:imitated_method)
-# obj.imitated_method
-# obj.imitated_method
+# obj.imitated_method #=> true
+# obj.imitated_method #=> true
 # obj.called_times(:imitated_method) #=> 2
 # ```

--- a/test/05_class_definition/test_simple_mock.rb
+++ b/test/05_class_definition/test_simple_mock.rb
@@ -27,7 +27,7 @@ class TestSimpleMock < MiniTest::Test
     assert_equal obj.imitated_method, expected
   end
 
-  def test_mock_retuns_setted_value_when_extended
+  def test_mock_returns_setted_value_when_extended
     obj = ClassForMockTest.new
     SimpleMock.mock(obj)
     expected = SecureRandom.hex
@@ -53,6 +53,17 @@ class TestSimpleMock < MiniTest::Test
     obj.watch(:imitated_method)
 
     obj.imitated_method
+    obj.imitated_method
+
+    assert_equal 2, obj.called_times(:imitated_method)
+  end
+
+  def test_mock_returns_value_and_counts_how_many_times
+    obj = SimpleMock.new
+    obj.expects(:imitated_method, 'hoge')
+    obj.watch(:imitated_method)
+
+    assert_equal('hoge', obj.imitated_method)
     obj.imitated_method
 
     assert_equal 2, obj.called_times(:imitated_method)

--- a/test/05_class_definition/test_simple_mock.rb
+++ b/test/05_class_definition/test_simple_mock.rb
@@ -64,7 +64,7 @@ class TestSimpleMock < MiniTest::Test
     obj.watch(:imitated_method)
 
     assert_equal('hoge', obj.imitated_method)
-    obj.imitated_method
+    assert_equal('hoge', obj.imitated_method)
 
     assert_equal 2, obj.called_times(:imitated_method)
   end


### PR DESCRIPTION
現状だと次のように、watchがexpectsで定義したメソッドを完全に上書きしてしまうコードを書いてもテストが通ってしまう

```ruby
def expects(name, value)
  define_singleton_method(name) do
    value
  end
end

def watch(name)
  (@counter ||= {})[name] = 0

  define_singleton_method(name) do
    @counter[name] += 1 if @counter&.key?(name)
  end
end
```