### PR TITLE
Fix duplicated test names

### DIFF
--- a/test/05_class_definition/test_simple_record.rb
+++ b/test/05_class_definition/test_simple_record.rb
@@ -5,7 +5,7 @@ require 'securerandom'
 class TestSimpleRecord < MiniTest::Test
   class Product
     include SimpleModel
-    
+
     attr_accessor :name, :description
   end
 
@@ -76,13 +76,13 @@ class TestSimpleRecord < MiniTest::Test
     attr_accessor :description
   end
 
-  def test_accessor
+  def test_multiple_accessors
     obj = MultipleAccessorsProduct.new(name: 'SmarterHR', description: 'more smart SmartHR')
     assert_equal 'SmarterHR', obj.name
     assert_equal 'more smart SmartHR', obj.description
   end
 
-  def test_writer
+  def test_multiple_accessors_writer
     obj = MultipleAccessorsProduct.new(name: 'SmarterHR', description: 'more smart SmartHR')
     obj.name = 'Ultra SmarterHR'
     obj.description = 'more smart SmarterHR'


### PR DESCRIPTION
#49 で追加したテストに不備がありましたので修正します :bow:

## Issue

重複したテスト名として定義されておりました。これによって走るべきテストが走らずに設定されておりました。

## Before

```
$ bundle exec ruby -Itest test/05_class_definition/test_simple_record.rb
Started with run options --seed 59098

  8/8: [==============================================================================================================================================] 100% Time: 00:00:00, Time: 00:00:00

Finished in 0.01071s
8 tests, 15 assertions, 0 failures, 0 errors, 0 skips
```

## After

```
$ bundle exec ruby -Itest test/05_class_definition/test_simple_record.rb
Started with run options --seed 24389

  10/10: [============================================================================================================================================] 100% Time: 00:00:00, Time: 00:00:00

Finished in 0.00305s
10 tests, 19 assertions, 0 failures, 0 errors, 0 skips
```