### PR TITLE
actions/checkoutをアップグレードした

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,9 +8,9 @@ jobs:
     env:
       CI: true
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
     - name: Build and test with Rake
       run: |
-        bundle install --jobs 4 --retry 3        
+        bundle install --jobs 4 --retry 3
         bundle exec rake


### PR DESCRIPTION
GitHub Actionsで次のように怒られていたのでバージョンを最新の4にアップグレードしました。

> build
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
